### PR TITLE
Add Docker Registry image

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,3 +10,6 @@
 
 # All .md files
 *.md @bszwarc @majakurcius @tomekpapiernik @kazydek @klaudiagrz @alexandra-simeonova @mmitoraj
+
+# The `distibution-library-image` repo
+/distribution-library-image/ @michal-hudy @m00g3n @aerfio @magicmatatjahu

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,8 +8,8 @@
 # These are the default owners for the whole content of the `fluentbit` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 * @a-thaler @hisarbalik @lilitgh @suleymanakbas91 @clebs @rakesh-garimella
 
-# All .md files
-*.md @bszwarc @majakurcius @tomekpapiernik @kazydek @klaudiagrz @alexandra-simeonova @mmitoraj
-
 # The `distibution-library-image` repo
 /distribution-library-image/ @michal-hudy @m00g3n @aerfio @magicmatatjahu
+
+# All .md files
+*.md @bszwarc @majakurcius @tomekpapiernik @kazydek @klaudiagrz @alexandra-simeonova @mmitoraj

--- a/distribution-library-image/Dockerfile
+++ b/distribution-library-image/Dockerfile
@@ -1,0 +1,17 @@
+# Build a minimal distribution container
+
+FROM alpine:3.11
+
+RUN set -ex \
+    && apk add --no-cache ca-certificates apache2-utils
+
+COPY ./registry /bin/registry
+COPY ./config-example.yml /etc/docker/registry/config.yml
+
+VOLUME ["/var/lib/registry"]
+EXPOSE 5000
+
+COPY docker-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["/etc/docker/registry/config.yml"]

--- a/distribution-library-image/Dockerfile
+++ b/distribution-library-image/Dockerfile
@@ -11,6 +11,8 @@ COPY ./config-example.yml /etc/docker/registry/config.yml
 VOLUME ["/var/lib/registry"]
 EXPOSE 5000
 
+LABEL source=git@github.com:kyma-project/kyma.git
+
 COPY docker-entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/distribution-library-image/Makefile
+++ b/distribution-library-image/Makefile
@@ -1,0 +1,24 @@
+APP_NAME ?= registry
+REGISTRY_VERSION = 2.7.1
+TAG = $(REGISTRY_VERSION)-$(DOCKER_TAG)
+IMG = $(DOCKER_PUSH_REPOSITORY)$(DOCKER_PUSH_DIRECTORY)/$(APP_NAME):$(TAG)
+
+# Build the docker image
+.PHONY: docker-build
+docker-build:
+	docker build . -t ${IMG}
+
+# Push the docker image
+.PHONY: docker-push
+docker-push:
+	docker push ${IMG}
+
+# CI specified targets
+.PHONY: ci-pr
+ci-pr: docker-build docker-push
+
+.PHONY: ci-master
+ci-master: docker-build docker-push
+
+.PHONY: ci-release
+ci-release: docker-build docker-push

--- a/distribution-library-image/README.md
+++ b/distribution-library-image/README.md
@@ -1,7 +1,5 @@
 # Docker Distribution
 
-Also known as Docker Registry.
-
-This image is based on the official [Docker Distribution image](https://registry.hub.docker.com/_/registry/).
+This folder contains the Docker Registry image that is based on the official [Docker Distribution image](https://registry.hub.docker.com/_/registry/).
 
 This custom image has been created to mitigate the security vulnerabilities the official image has.

--- a/distribution-library-image/README.md
+++ b/distribution-library-image/README.md
@@ -1,0 +1,7 @@
+# Docker Distribution
+
+Also known as Docker Registry.
+
+This image is based on the official [Docker Distribution image](https://registry.hub.docker.com/_/registry/).
+
+This custom image has been created to mitigate the security vulnerabilities the official image has.

--- a/distribution-library-image/config-example.yml
+++ b/distribution-library-image/config-example.yml
@@ -1,0 +1,18 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: :5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/distribution-library-image/docker-entrypoint.sh
+++ b/distribution-library-image/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    *.yaml|*.yml) set -- registry serve "$@" ;;
+    serve|garbage-collect|help|-*) set -- registry "$@" ;;
+esac
+
+exec "$@"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add docker registry image to mitigate the security vulnerabilities the official image has.

Source taken from https://github.com/docker/distribution-library-image/, from `amd64` directory. The only change made to it is that we are using `alpine:3.11` instead of `alpine:3.8`.

I've added our team to CODEOWNERS, just for this folder, is it ok for you?

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
