### PR TITLE
update k8s-sidecar to newest python base image

### DIFF
--- a/kiali-operator/Dockerfile
+++ b/kiali-operator/Dockerfile
@@ -38,4 +38,4 @@ LABEL source=git@github.com:kyma-project/kyma.git
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/entrypoint"]
 
-USER ${USER_UID}
+USER ${USER_UID} 

--- a/kiali/Dockerfile
+++ b/kiali/Dockerfile
@@ -19,6 +19,6 @@ RUN adduser -D kiali && \
 
 LABEL source=git@github.com:kyma-project/kyma.git
 
-USER kiali
+USER kiali 
 
 ENTRYPOINT ["/opt/kiali/kiali"]

--- a/kiwigrid-sidecar/Dockerfile
+++ b/kiwigrid-sidecar/Dockerfile
@@ -1,6 +1,6 @@
 FROM kiwigrid/k8s-sidecar:0.1.178 as builder
 
-FROM python:3.9.0b5-alpine3.12
+FROM python:3.9.0rc1-alpine3.12
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- update k8s-sidecar to newest python base image
- added space to kiali-operator to trigger rebuild of image
- added space to kiali to trigger rebuild of image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
