### PR TITLE
Add inotify-tools to k8s-tools

### DIFF
--- a/k8s-tools/Dockerfile
+++ b/k8s-tools/Dockerfile
@@ -11,7 +11,7 @@ LABEL source=git@github.com:kyma-project/third-party-images.git
 ENV KUBECTL_VERSION="v1.19.7"
 
 RUN apk --no-cache upgrade &&\
-    apk --no-cache add openssl coreutils curl bash jq grep &&\
+    apk --no-cache add openssl coreutils curl bash jq grep inotify-tools &&\
     wget https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl &&\
     chmod +x /usr/local/bin/kubectl
 


### PR DESCRIPTION
**Description**
One of Kyma Pods uses `inotify-tools` to watch for file changes.
We can't add this packages at runtime because Pod SecurityContext prevents running it as `root` user.
We have to add all required packages to the base Docker image.

Changes proposed in this pull request:

- Add inotify-tools to the k8s-tools Docker image.

**Related issue(s)**
See also: https://github.com/kyma-project/kyma/pull/10834